### PR TITLE
Fixed bug with empty parameters

### DIFF
--- a/src/SecurityChecker/Command/SecurityCheckerCommand.php
+++ b/src/SecurityChecker/Command/SecurityCheckerCommand.php
@@ -83,11 +83,11 @@ class SecurityCheckerCommand extends Command
     {
         $parameters = [];
 
-        if ($input->hasOption(static::OPTION_PATH) && $input->getOption(static::OPTION_PATH)) {
+        if ($input->getOption(static::OPTION_PATH)) {
             $parameters[] = sprintf('--%s=%s', static::OPTION_PATH, $input->getOption(static::OPTION_PATH));
         }
 
-        if ($input->hasOption(static::OPTION_FORMAT) && $input->getOption(static::OPTION_FORMAT)) {
+        if ($input->getOption(static::OPTION_FORMAT)) {
             $parameters[] = sprintf('--%s=%s', static::OPTION_FORMAT, $input->getOption(static::OPTION_FORMAT));
         }
 

--- a/src/SecurityChecker/Command/SecurityCheckerCommand.php
+++ b/src/SecurityChecker/Command/SecurityCheckerCommand.php
@@ -83,11 +83,11 @@ class SecurityCheckerCommand extends Command
     {
         $parameters = [];
 
-        if ($input->hasOption(static::OPTION_PATH)) {
+        if ($input->hasOption(static::OPTION_PATH) && $input->getOption(static::OPTION_PATH)) {
             $parameters[] = sprintf('--%s=%s', static::OPTION_PATH, $input->getOption(static::OPTION_PATH));
         }
 
-        if ($input->hasOption(static::OPTION_FORMAT)) {
+        if ($input->hasOption(static::OPTION_FORMAT) && $input->getOption(static::OPTION_FORMAT)) {
             $parameters[] = sprintf('--%s=%s', static::OPTION_FORMAT, $input->getOption(static::OPTION_FORMAT));
         }
 

--- a/src/SecurityChecker/Command/SecurityCheckerCommand.php
+++ b/src/SecurityChecker/Command/SecurityCheckerCommand.php
@@ -43,14 +43,12 @@ class SecurityCheckerCommand extends Command
                 'f',
                 InputOption::VALUE_OPTIONAL,
                 'Set format for checker',
-                false,
             )
             ->addOption(
                 static::OPTION_PATH,
                 'p',
                 InputOption::VALUE_OPTIONAL,
                 'Set path for checker',
-                false,
             );
     }
 


### PR DESCRIPTION
Follow https://github.com/spryker-sdk/security-checker/pull/4/files


- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SecurityChecker              | patch                 |                       |

-----------------------------------------

#### Module SecurityChecker

##### Change log

Fixes

- Adjusted `SecurityCheckerCommand` so it checks that parameters are not empty.
